### PR TITLE
Also make b, em, i, and div use !important overrides

### DIFF
--- a/assets/css/app/accesibility.css
+++ b/assets/css/app/accesibility.css
@@ -47,7 +47,7 @@ p:hover, li:hover {
 }
 
 
-p, a, h1, h2, h3, h4, h5, input, ul, span, font, strong {
+p, a, h1, h2, h3, h4, h5, input, ul, span, font, strong, b, em, i, div {
 	font-family: opendyslexic !important;
 	line-height: 150%;
 }


### PR DESCRIPTION
Have a few more elements use !important override for the font.

This should fix the duckduckgo.com homepage (which uses a body->div with text). You can see that currently, the "The search engine that doesn't track you." text is not rendered in the opendyslexic font.

And it adds b, em, and i which seem a lot like strong, which is already included in that selector.