### PR TITLE
Fix the way OpenDyslexic chrome extension handles icon fonts

### DIFF
--- a/assets/css/app/accesibility.css
+++ b/assets/css/app/accesibility.css
@@ -33,9 +33,14 @@
 	font-style: normal;
 }
 
+:root {
+    --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, 'Glyphicons Halflings', sans-serif;
+    --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, 'Glyphicons Halflings', monospace;
+}
+
 html {
 	color: rgb(25, 26, 66);
-	font-family: opendyslexic;
+	font-family: var(--opendyslexic-chrome-sans);
 }
 
 p:nth-child(even), li:nth-child(even) {
@@ -48,21 +53,21 @@ p:hover, li:hover {
 
 
 p, a, h1, h2, h3, h4, h5, input, ul, span, font, strong {
-	font-family: opendyslexic !important;
+	font-family: var(--opendyslexic-chrome-sans) !important;
 	line-height: 150%;
 }
 
 * {
-	font-family: opendyslexic;
+	font-family: var(--opendyslexic-chrome-sans);
 }
 
 pre, code {
-	font-family: opendyslexicmono !important;
+	font-family: var(--opendyslexic-chrome-mono) !important;
 	line-height: 150%;
 }
 
 .ace_text-input, .prettyprint {
-	font-family: opendyslexicmono !important;
+	font-family: var(--opendyslexic-chrome-mono) !important;
 }
 
 .original-tweet {
@@ -70,14 +75,14 @@ pre, code {
 }
 
 input, textarea {
-	font-family: opendyslexic !important;
+	font-family: var(--opendyslexic-chrome-sans) !important;
 }
 
 
 /* NYTimes Support */
 
 .story.theme-summary .summary, .span-ab-bottom-region .story.theme-summary .summary, .inside-nyt .story.theme-summary .story-heading, .well .column ul li .story .story-heading, .inside-nyt .story.theme-summary.no-thumb .story-heading, .inside-nyt .story.theme-summary .summary, .recommendations ol li .story-heading, .tone-news .story.theme-main .story-header .story-heading, .type-size-small .story.theme-main .story-body-text, .story.theme-summary .story-heading {
-	font-family: opendyslexic;
+	font-family: var(--opendyslexic-chrome-sans);
 	line-height: 150%;
 }
 
@@ -85,6 +90,6 @@ input, textarea {
 /* WSJ Support */
 
 article .article_header h1, article p {
-	font-family: opendyslexic;
+	font-family: var(--opendyslexic-chrome-sans);
 	line-height: 150%;
 }


### PR DESCRIPTION
(This PR created with @BessieSteinberg. Cheers, Bessie!)

**Problem:** Font icons, like Font Awesome, Glyphicon and Elusive Icons, are fonts that instead of rendering traditional characters will render images that can be styled just like traditional fonts.  The OpenDyslexic chrome extension doesn’t handle icon fonts well.  Instead of showing the appropriate icon it will show an empty box.  This can be confusing and can inhibit a users ability to navigate a website as font icons are often used to express the meaning of buttons.

**Example:**

The [edX homepage](https://www.edx.org/) uses uses a number of common design paradigms for font icons.  (Specifically edX uses Font Awesome)
- It uses arrows in the header to communicate drop down menus
- Links to social media accounts are indicated by font icons with social media logos

<img width="1440" alt="open-dyslexic-off-1" src="https://user-images.githubusercontent.com/1196901/35643230-aef5df52-0693-11e8-8b2f-f5d4a12583f7.png">
<img width="1440" alt="open-dyslexic-off-2" src="https://user-images.githubusercontent.com/1196901/35643044-111d5832-0693-11e8-8c7f-0c19f819dff5.png">

The next example shows the edX homepage with the OpenDyslexic extension turned on.  All of the Font Awesome icons used on the page are turned into boxes, which makes navigating the page confusing.  
- It’s not easy to see that ‘About’ has a drop down menu because instead an arrow to indicate a drop down menu there is now an empty box!  
- Even more confusing, all of the social media links have been replaced by empty boxes.  So it's impossible to see which button goes to which social media!  

<img width="1440" alt="open-dyslexic-on-1" src="https://user-images.githubusercontent.com/1196901/35643218-a0e91974-0693-11e8-9ca2-68d0166ccc48.png">
<img width="1440" alt="open-dyslexic-on-2" src="https://user-images.githubusercontent.com/1196901/35643120-4fc755a6-0693-11e8-9b7c-94b23500834f.png">

The reason this is happening is that whenever the extension sees a unicode character that is not included in the OpenDyslexic font it just defaults to an empty box.


**Solution:**

Our solution is to include a few of the common icon fonts as fallback fonts.

```css
:root {
   --opendyslexic-chrome-sans: opendyslexic, Elusive-Icons, FontAwesome, 'Glyphicons Halflings', sans-serif;
   --opendyslexic-chrome-mono: opendyslexicmono, Elusive-Icons, FontAwesome, 'Glyphicons Halflings', monospace;
}
```

If a character falls outside of the unicode range OpenDyslexic knows, it will try to match it to Elusive-Icons, then to FontAwesome, then to Glyphicons Halflings and finally if it doesn’t match any of those it will default to sans-serif or mono depending on which font family is being used.

With our change the edX homepage now looks like this:
(Notice that all the normal characters are rendered as OpenDyslexic but all of the Font Awesome characters are rendered as icons.)

![homepagetop](https://user-images.githubusercontent.com/1196901/35642898-93a96454-0692-11e8-997a-90878a42fef3.png)

![homepagebottom](https://user-images.githubusercontent.com/1196901/35642901-9769a5a4-0692-11e8-9cac-c92b238a03d5.png)
